### PR TITLE
Fix typo in the watchlist query

### DIFF
--- a/src/plugins/Watchlist/store.js
+++ b/src/plugins/Watchlist/store.js
@@ -65,7 +65,7 @@ module.exports = function storeModule(conf) {
         if (count == null) {
           count = (await WM.MW.callAPIGet({
             list: 'watchlist',
-            wlimit: 'max',
+            wllimit: 'max',
             wlnamespace: '*',
             wlprop: 'ids',
             wlshow: 'unread',


### PR DESCRIPTION
The parameter is named 'wllimit', not 'wlimit'. The unrecognized name
was ignored and I was always getting 10 as the result, because the
plugin does not do repeated calls for query-continuation.